### PR TITLE
Adds token password support to check expansion script

### DIFF
--- a/check-expansion.sh
+++ b/check-expansion.sh
@@ -21,20 +21,42 @@ if [ $DEBUG = '--debug' ]; then
     echo "  ACR_TAG : ${ACR_TAG}"
 fi
 
+echo "Getting Access Token"
+
+ACR_ACCESS_TOKEN=$(curl -s -u ${ACR_USER}:${ACR_PWD} "https://${ACR_NAME}.azurecr.io/oauth2/token?service=${ACR_NAME}.azurecr.io&scope=repository:${ACR_REPO}:pull" | sed -e 's/[{}]/''/g' | awk -v RS=',"' -F: '/access_token/ {print $2}' | sed 's/^.//;s/.$//')
+
+if [[ $ACR_ACCESS_TOKEN == '' ]]; then
+    echo "Could not get access token, make sure credentials are accurate and have pull access"
+    exit 1
+fi
+
+if [[ $DEBUG == '--debug' ]]; then
+    echo "  ACR_ACCESS_TOKEN: ${ACR_ACCESS_TOKEN}"
+fi
+
 echo "Finding Digest for $ACR_REPO:$ACR_TAG https://$ACR_NAME.azurecr.io/v2/$ACR_REPO/manifests/$ACR_TAG"
 
-ACR_DIGEST=$(curl -s -L -u "$ACR_USER:$ACR_PWD" -I \
+ACR_DIGEST=$(curl -s -L -I \
   -H "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+  -H "Authorization: Bearer ${ACR_ACCESS_TOKEN}" \
   https://$ACR_NAME.azurecr.io/v2/$ACR_REPO/manifests/$ACR_TAG | grep ^Docker-Content-Digest | awk '{print $2}' | head -c 71)
 
-if [ $DEBUG = '--debug' ]; then
+if [[ $DEBUG == '--debug' ]]; then
     echo "  ACR_DIGEST: ${ACR_DIGEST}"
+fi
+
+if [[ $ACR_DIGEST == '' ]]; then
+    echo "Could not get image digest, make sure this tag exists"
+    exit 1
 fi
 
 echo "Checking https://$ACR_NAME.azurecr.io/mount/v1/$ACR_REPO/_manifests/$ACR_DIGEST"
 while true
 do
-    STATUS=$(curl -s -o /dev/null -w "%{http_code}" -u "$ACR_USER:$ACR_PWD" "https://$ACR_NAME.azurecr.io/mount/v1/$ACR_REPO/_manifests/$ACR_DIGEST")
+    STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+    -H "Authorization: Bearer ${ACR_ACCESS_TOKEN}" \
+    "https://$ACR_NAME.azurecr.io/mount/v1/$ACR_REPO/_manifests/$ACR_DIGEST")
+
     echo "Status: ${STATUS}"
     if [ $STATUS -eq 200 ]; then
         echo "Teleport: layers ready"


### PR DESCRIPTION
This commit adjusts the auth flow to support token passwords by doing an additional call to request an acr access token, it also adds some further debugging information and feedback (e.g Will notify the user on failure to identify the digest for a given tag.)